### PR TITLE
Bump Golang version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Generate coverage report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x,]
+        go-version: [1.21.x,]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TimothyStiles/poly
 
-go 1.21.4
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TimothyStiles/poly
 
-go 1.18
+go 1.21.4
 
 require (
 	github.com/google/go-cmp v0.5.8
@@ -9,6 +9,7 @@ require (
 	github.com/mroth/weightedrand v0.4.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/sergi/go-diff v1.2.0
+	github.com/spaolacci/murmur3 v1.1.0
 	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
 	lukechampine.com/blake3 v1.1.5
 )
@@ -16,7 +17,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-sqlite3 v1.14.13 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
 )
 
 require (

--- a/io/slow5/slow5_test.go
+++ b/io/slow5/slow5_test.go
@@ -3,7 +3,6 @@ package slow5
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -190,11 +189,11 @@ func TestWrite(t *testing.T) {
 	}
 
 	// Compare both files
-	example, err := ioutil.ReadFile("data/example.slow5")
+	example, err := os.ReadFile("data/example.slow5")
 	if err != nil {
 		t.Errorf("Failed to read example file: %s", err)
 	}
-	testWrite, err := ioutil.ReadFile("data/test_write.slow5")
+	testWrite, err := os.ReadFile("data/test_write.slow5")
 	if err != nil {
 		t.Errorf("Failed to read test file: %s", err)
 	}

--- a/random/random.go
+++ b/random/random.go
@@ -19,7 +19,7 @@ func ProteinSequence(length int, seed int64) (string, error) {
 
 	// https://en.wikipedia.org/wiki/Amino_acid#Table_of_standard_amino_acid_abbreviations_and_properties
 	var aminoAcidsAlphabet = []rune("ACDEFGHIJLMNPQRSTVWY")
-	rand.Seed(seed)
+	randomSource := rand.New(rand.NewSource(seed))
 
 	randomSequence := make([]rune, length)
 
@@ -31,7 +31,7 @@ func ProteinSequence(length int, seed int64) (string, error) {
 			//* is the standard abbreviation for the stop codon. That's a signal for the ribosome to stop the translation and because of that a protein sequence is finished with *
 			randomSequence[peptide] = '*'
 		} else {
-			randomIndex := rand.Intn(len(aminoAcidsAlphabet))
+			randomIndex := randomSource.Intn(len(aminoAcidsAlphabet))
 			randomSequence[peptide] = aminoAcidsAlphabet[randomIndex]
 		}
 	}

--- a/random/random.go
+++ b/random/random.go
@@ -51,7 +51,7 @@ func RNASequence(length int, seed int64) (string, error) {
 
 func randomNucelotideSequence(length int, seed int64, alphabet []rune) string {
 	alphabetLength := len(alphabet)
-	rand.Seed(seed)
+	rand := rand.New(rand.NewSource(seed))
 
 	randomSequence := make([]rune, length)
 	for basepair := range randomSequence {

--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -149,11 +149,13 @@ func (table *TranslationTable) OptimizeSequence(aminoAcids string, randomState .
 	}
 
 	// weightedRand library insisted setting seed like this. Not sure what environmental side effects exist.
+	var randomSource rand.Source
 	if len(randomState) > 0 {
-		rand.Seed(int64(randomState[0]))
+		randomSource = rand.NewSource(int64(randomState[0]))
 	} else {
-		rand.Seed(time.Now().UTC().UnixNano())
+		randomSource = rand.NewSource(time.Now().UTC().UnixNano())
 	}
+	rand := rand.New(randomSource)
 
 	var codons strings.Builder
 	codonChooser := table.Choosers
@@ -163,6 +165,7 @@ func (table *TranslationTable) OptimizeSequence(aminoAcids string, randomState .
 		if !ok {
 			return "", invalidAminoAcidError{aminoAcid}
 		}
+		chooser.PickSource(rand)
 
 		codons.WriteString(chooser.Pick().(string))
 	}

--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -165,9 +165,9 @@ func (table *TranslationTable) OptimizeSequence(aminoAcids string, randomState .
 		if !ok {
 			return "", invalidAminoAcidError{aminoAcid}
 		}
-		chooser.PickSource(rand)
+		codon := chooser.PickSource(rand)
 
-		codons.WriteString(chooser.Pick().(string))
+		codons.WriteString(codon.(string))
 	}
 
 	return codons.String(), nil


### PR DESCRIPTION
## Changes in this PR
Bumps Golang version to latest stable one:  [1.21.4](https://go.dev/dl/)

Also ran `go mod tidy`.

### Why are you making these changes?

Just keeping it up to date and I also think there can be many benefits, for example I explored the new `slices` package which is recommended and more performant than `sort` methods in a few scenarios, etc.

### Are any changes breaking? (IMPORTANT)
No - tests are fine too

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [ ] New packages/exported functions have docstrings.
* [ ] New/changed functionality is thoroughly tested.
* [ ] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [ ] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [ ] All code is properly formatted and linted.
* [x] The PR template is filled out.
