### PR TITLE
Fixing updateweights example

### DIFF
--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -385,7 +385,7 @@ Tim
 ******************************************************************************/
 
 // Function to generate default codon tables from NCBI https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi
-func generateCodonTable(aminoAcids, starts string) *TranslationTable {
+func generateCodonTable(aminoAcids, starts string) (*TranslationTable, error) {
 	base1 := "TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG"
 	base2 := "TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG"
 	base3 := "TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG"
@@ -432,7 +432,7 @@ func generateCodonTable(aminoAcids, starts string) *TranslationTable {
 	// This function is run at buildtime and failure here means we have an invalid codon table.
 	chooser, err := newAminoAcidChoosers(aminoAcidSlice)
 	if err != nil {
-		panic(fmt.Errorf("tried to generate an invalid codon table %w", err))
+		return nil, fmt.Errorf("tried to generate an invalid codon table %w", err)
 	}
 
 	return &TranslationTable{
@@ -443,41 +443,42 @@ func generateCodonTable(aminoAcids, starts string) *TranslationTable {
 		StartCodonTable: startCodonsMap,
 		Choosers:        chooser,
 		Stats:           NewStats(),
-	}
+	}, nil
 }
 
 // NewTranslationTable takes the index of desired NCBI codon table and returns it.
-func NewTranslationTable(index int) *TranslationTable {
-	return translationTablesByNumber[index].Copy()
+func NewTranslationTable(index int) (*TranslationTable, error) {
+	return generateCodonTable(translationTablesByNumber[index][0], translationTablesByNumber[index][1])
 }
 
-// translationTablesByNumber stores all codon tables published by NCBI https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi using numbered indices.
-var translationTablesByNumber = map[int]*TranslationTable{
-	1:  generateCodonTable("FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**--*----M---------------M----------------------------"),
-	2:  generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSS**VVVVAAAADDEEGGGG", "----------**--------------------MMMM----------**---M------------"),
-	3:  generateCodonTable("FFLLSSSSYY**CCWWTTTTPPPPHHQQRRRRIIMMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**----------------------MM---------------M------------"),
-	4:  generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--MM------**-------M------------MMMM---------------M------------"),
-	5:  generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSSSSVVVVAAAADDEEGGGG", "---M------**--------------------MMMM---------------M------------"),
-	6:  generateCodonTable("FFLLSSSSYYQQCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"),
-	9:  generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "----------**-----------------------M---------------M------------"),
-	10: generateCodonTable("FFLLSSSSYY**CCCWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**-----------------------M----------------------------"),
-	11: generateCodonTable("FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**--*----M------------MMMM---------------M------------"),
-	12: generateCodonTable("FFLLSSSSYY**CC*WLLLSPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*----M---------------M----------------------------"),
-	13: generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSSGGVVVVAAAADDEEGGGG", "---M------**----------------------MM---------------M------------"),
-	14: generateCodonTable("FFLLSSSSYYY*CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "-----------*-----------------------M----------------------------"),
-	16: generateCodonTable("FFLLSSSSYY*LCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------*---*--------------------M----------------------------"),
-	21: generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "----------**-----------------------M---------------M------------"),
-	22: generateCodonTable("FFLLSS*SYY*LCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "------*---*---*--------------------M----------------------------"),
-	23: generateCodonTable("FF*LSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--*-------**--*-----------------M--M---------------M------------"),
-	24: generateCodonTable("FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSSKVVVVAAAADDEEGGGG", "---M------**-------M---------------M---------------M------------"),
-	25: generateCodonTable("FFLLSSSSYY**CCGWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**-----------------------M---------------M------------"),
-	26: generateCodonTable("FFLLSSSSYY**CC*WLLLAPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*----M---------------M----------------------------"),
-	27: generateCodonTable("FFLLSSSSYYQQCCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"),
-	28: generateCodonTable("FFLLSSSSYYQQCCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*--------------------M----------------------------"),
-	29: generateCodonTable("FFLLSSSSYYYYCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"),
-	30: generateCodonTable("FFLLSSSSYYEECC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"),
-	31: generateCodonTable("FFLLSSSSYYEECCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**-----------------------M----------------------------"),
-	33: generateCodonTable("FFLLSSSSYYY*CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSSKVVVVAAAADDEEGGGG", "---M-------*-------M---------------M---------------M------------")}
+// translationTablesByNumber stores all data necessary to generate codon tables from sequences published by NCBI https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi using numbered indices.
+var translationTablesByNumber = map[int][]string{
+	1:  {"FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**--*----M---------------M----------------------------"},
+	2:  {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSS**VVVVAAAADDEEGGGG", "----------**--------------------MMMM----------**---M------------"},
+	3:  {"FFLLSSSSYY**CCWWTTTTPPPPHHQQRRRRIIMMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**----------------------MM---------------M------------"},
+	4:  {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--MM------**-------M------------MMMM---------------M------------"},
+	5:  {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSSSSVVVVAAAADDEEGGGG", "---M------**--------------------MMMM---------------M------------"},
+	6:  {"FFLLSSSSYYQQCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"},
+	9:  {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "----------**-----------------------M---------------M------------"},
+	10: {"FFLLSSSSYY**CCCWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**-----------------------M----------------------------"},
+	11: {"FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**--*----M------------MMMM---------------M------------"},
+	12: {"FFLLSSSSYY**CC*WLLLSPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*----M---------------M----------------------------"},
+	13: {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSSGGVVVVAAAADDEEGGGG", "---M------**----------------------MM---------------M------------"},
+	14: {"FFLLSSSSYYY*CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "-----------*-----------------------M----------------------------"},
+	16: {"FFLLSSSSYY*LCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------*---*--------------------M----------------------------"},
+	21: {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNNKSSSSVVVVAAAADDEEGGGG", "----------**-----------------------M---------------M------------"},
+	22: {"FFLLSS*SYY*LCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "------*---*---*--------------------M----------------------------"},
+	23: {"FF*LSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--*-------**--*-----------------M--M---------------M------------"},
+	24: {"FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSSKVVVVAAAADDEEGGGG", "---M------**-------M---------------M---------------M------------"},
+	25: {"FFLLSSSSYY**CCGWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "---M------**-----------------------M---------------M------------"},
+	26: {"FFLLSSSSYY**CC*WLLLAPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*----M---------------M----------------------------"},
+	27: {"FFLLSSSSYYQQCCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"},
+	28: {"FFLLSSSSYYQQCCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**--*--------------------M----------------------------"},
+	29: {"FFLLSSSSYYYYCC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"},
+	30: {"FFLLSSSSYYEECC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "--------------*--------------------M----------------------------"},
+	31: {"FFLLSSSSYYEECCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG", "----------**-----------------------M----------------------------"},
+	33: {"FFLLSSSSYYY*CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSSKVVVVAAAADDEEGGGG", "---M-------*-------M---------------M---------------M------------"},
+}
 
 /******************************************************************************
 Nov, 20, 2020

--- a/synthesis/codon/codon_test.go
+++ b/synthesis/codon/codon_test.go
@@ -16,14 +16,23 @@ func TestTranslation(t *testing.T) {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	gfpDnaSequence := "ATGGCTAGCAAAGGAGAAGAACTTTTCACTGGAGTTGTCCCAATTCTTGTTGAATTAGATGGTGATGTTAATGGGCACAAATTTTCTGTCAGTGGAGAGGGTGAAGGTGATGCTACATACGGAAAGCTTACCCTTAAATTTATTTGCACTACTGGAAAACTACCTGTTCCATGGCCAACACTTGTCACTACTTTCTCTTATGGTGTTCAATGCTTTTCCCGTTATCCGGATCATATGAAACGGCATGACTTTTTCAAGAGTGCCATGCCCGAAGGTTATGTACAGGAACGCACTATATCTTTCAAAGATGACGGGAACTACAAGACGCGTGCTGAAGTCAAGTTTGAAGGTGATACCCTTGTTAATCGTATCGAGTTAAAAGGTATTGATTTTAAAGAAGATGGAAACATTCTCGGACACAAACTCGAGTACAACTATAACTCACACAATGTATACATCACGGCAGACAAACAAAAGAATGGAATCAAAGCTAACTTCAAAATTCGCCACAACATTGAAGATGGATCCGTTCAACTAGCAGACCATTATCAACAAAATACTCCAATTGGCGATGGCCCTGTCCTTTTACCAGACAACCATTACCTGTCGACACAATCTGCCCTTTCGAAAGATCCCAACGAAAAGCGTGACCACATGGTCCTTCTTGAGTTTGTAACTGCTGCTGGGATTACACATGGCATGGATGAGCTCTACAAATAA"
 
-	if got, _ := NewTranslationTable(11).Translate(gfpDnaSequence); got != gfpTranslation {
+	table, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	if got, _ := table.Translate(gfpDnaSequence); got != gfpTranslation {
 		t.Errorf("TestTranslation has failed. Translate has returned %q, want %q", got, gfpTranslation)
 	}
 }
 
 func TestTranslationErrorsOnEmptyAminoAcidString(t *testing.T) {
-	nonEmptyCodonTable := NewTranslationTable(1)
-	_, err := nonEmptyCodonTable.Translate("")
+	nonEmptyCodonTable, err := NewTranslationTable(1)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	_, err = nonEmptyCodonTable.Translate("")
 
 	if err != errEmptySequenceString {
 		t.Error("Translation should return an error if given an empty sequence string")
@@ -33,7 +42,12 @@ func TestTranslationErrorsOnEmptyAminoAcidString(t *testing.T) {
 func TestTranslationMixedCase(t *testing.T) {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	gfpDnaSequence := "atggctagcaaaggagaagaacttttcactggagttgtcccaaTTCTTGTTGAATTAGATGGTGATGTTAATGGGCACAAATTTTCTGTCAGTGGAGAGGGTGAAGGTGATGCTACATACGGAAAGCTTACCCTTAAATTTATTTGCACTACTGGAAAACTACCTGTTCCATGGCCAACACTTGTCACTACTTTCTCTTATGGTGTTCAATGCTTTTCCCGTTATCCGGATCATATGAAACGGCATGACTTTTTCAAGAGTGCCATGCCCGAAGGTTATGTACAGGAACGCACTATATCTTTCAAAGATGACGGGAACTACAAGACGCGTGCTGAAGTCAAGTTTGAAGGTGATACCCTTGTTAATCGTATCGAGTTAAAAGGTATTGATTTTAAAGAAGATGGAAACATTCTCGGACACAAACTCGAGTACAACTATAACTCACACAATGTATACATCACGGCAGACAAACAAAAGAATGGAATCAAAGCTAACTTCAAAATTCGCCACAACATTGAAGATGGATCCGTTCAACTAGCAGACCATTATCAACAAAATACTCCAATTGGCGATGGCCCTGTCCTTTTACCAGACAACCATTACCTGTCGACACAATCTGCCCTTTCGAAAGATCCCAACGAAAAGCGTGACCACATGGTCCTTCTTGAGTTTGTAACTGCTGCTGGGATTACACATGGCATGGATGAGCTCTACAAATAA"
-	if got, _ := NewTranslationTable(11).Translate(gfpDnaSequence); got != gfpTranslation {
+	table, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	if got, _ := table.Translate(gfpDnaSequence); got != gfpTranslation {
 		t.Errorf("TestTranslationMixedCase has failed. Translate has returned %q, want %q", got, gfpTranslation)
 	}
 }
@@ -41,7 +55,13 @@ func TestTranslationMixedCase(t *testing.T) {
 func TestTranslationLowerCase(t *testing.T) {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	gfpDnaSequence := "atggctagcaaaggagaagaacttttcactggagttgtcccaattcttgttgaattagatggtgatgttaatgggcacaaattttctgtcagtggagagggtgaaggtgatgctacatacggaaagcttacccttaaatttatttgcactactggaaaactacctgttccatggccaacacttgtcactactttctcttatggtgttcaatgcttttcccgttatccggatcatatgaaacggcatgactttttcaagagtgccatgcccgaaggttatgtacaggaacgcactatatctttcaaagatgacgggaactacaagacgcgtgctgaagtcaagtttgaaggtgatacccttgttaatcgtatcgagttaaaaggtattgattttaaagaagatggaaacattctcggacacaaactcgagtacaactataactcacacaatgtatacatcacggcagacaaacaaaagaatggaatcaaagctaacttcaaaattcgccacaacattgaagatggatccgttcaactagcagaccattatcaacaaaatactccaattggcgatggccctgtccttttaccagacaaccattacctgtcgacacaatctgccctttcgaaagatcccaacgaaaagcgtgaccacatggtccttcttgagtttgtaactgctgctgggattacacatggcatggatgagctctacaaataa"
-	if got, _ := NewTranslationTable(11).Translate(gfpDnaSequence); got != gfpTranslation {
+
+	table, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	if got, _ := table.Translate(gfpDnaSequence); got != gfpTranslation {
 		t.Errorf("TestTranslationLowerCase has failed. Translate has returned %q, want %q", got, gfpTranslation)
 	}
 }
@@ -51,13 +71,20 @@ func TestOptimize(t *testing.T) {
 
 	sequence, _ := genbank.Read("../../data/puc19.gbk")
 
-	table := NewTranslationTable(11)
-	err := table.UpdateWeightsWithSequence(sequence)
+	table, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = table.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
 
-	codonTable := NewTranslationTable(11)
+	codonTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
 
 	optimizedSequence, _ := table.Optimize(gfpTranslation)
 	optimizedSequenceTranslation, _ := codonTable.Translate(optimizedSequence)
@@ -70,8 +97,12 @@ func TestOptimize(t *testing.T) {
 func TestOptimizeSameSeed(t *testing.T) {
 	var gfpTranslation = "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	var sequence, _ = genbank.Read("../../data/puc19.gbk")
-	optimizationTable := NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,8 +123,12 @@ func TestOptimizeSameSeed(t *testing.T) {
 func TestOptimizeDifferentSeed(t *testing.T) {
 	var gfpTranslation = "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	var sequence, _ = genbank.Read("../../data/puc19.gbk")
-	optimizationTable := NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
@@ -107,8 +142,12 @@ func TestOptimizeDifferentSeed(t *testing.T) {
 }
 
 func TestOptimizeErrorsOnEmptyAminoAcidString(t *testing.T) {
-	nonEmptyCodonTable := NewTranslationTable(1)
-	_, err := nonEmptyCodonTable.Optimize("")
+	nonEmptyCodonTable, err := NewTranslationTable(1)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	_, err = nonEmptyCodonTable.Optimize("")
 
 	if err != errEmptyAminoAcidString {
 		t.Error("Optimize should return an error if given an empty amino acid string")
@@ -116,14 +155,22 @@ func TestOptimizeErrorsOnEmptyAminoAcidString(t *testing.T) {
 }
 func TestOptimizeErrorsOnInvalidAminoAcid(t *testing.T) {
 	aminoAcids := "TOP"
-	table := NewTranslationTable(1) // does not contain 'O'
+	table, err := NewTranslationTable(1)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+	// does not contain 'O'
 
 	_, optimizeErr := table.Optimize(aminoAcids)
 	assert.EqualError(t, optimizeErr, invalidAminoAcidError{'O'}.Error())
 }
 
 func TestGetCodonFrequency(t *testing.T) {
-	translationTable := NewTranslationTable(11).TranslationMap
+	table, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+	translationTable := table.TranslationMap
 
 	var codons strings.Builder
 
@@ -197,14 +244,22 @@ func TestCompromiseCodonTable(t *testing.T) {
 
 	// weight our codon optimization table using the regions we collected from the genbank file above
 
-	optimizationTable := NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
 
 	sequence2, _ := genbank.Read("../../data/phix174.gb")
-	optimizationTable2 := NewTranslationTable(11)
+	optimizationTable2, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
 	err = optimizationTable2.UpdateWeightsWithSequence(sequence2)
 	if err != nil {
 		t.Error(err)
@@ -239,14 +294,22 @@ func TestAddCodonTable(t *testing.T) {
 
 	// weight our codon optimization table using the regions we collected from the genbank file above
 
-	optimizationTable := NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
 
 	sequence2, _ := genbank.Read("../../data/phix174.gb")
-	optimizationTable2 := NewTranslationTable(11)
+	optimizationTable2, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
 	err = optimizationTable2.UpdateWeightsWithSequence(sequence2)
 	if err != nil {
 		t.Error(err)
@@ -273,8 +336,12 @@ func TestCapitalizationRegression(t *testing.T) {
 
 	sequence, _ := genbank.Read("../../data/puc19.gbk")
 
-	optimizationTable := NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := NewTranslationTable(11)
+	if err != nil {
+		t.Fatalf("failed to initialise codon table: %s", err)
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		t.Error(err)
 	}
@@ -350,8 +417,12 @@ func TestOptimizeSequence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			optimizationTable := NewTranslationTable(11)
-			err := optimizationTable.UpdateWeightsWithSequence(tt.updateWeightsWith)
+			optimizationTable, err := NewTranslationTable(11)
+			if err != nil {
+				t.Fatalf("failed to initialise codon table: %s", err)
+			}
+
+			err = optimizationTable.UpdateWeightsWithSequence(tt.updateWeightsWith)
 			if !errors.Is(err, tt.wantUpdateWeightsErr) {
 				t.Errorf("got %v, want %v", err, tt.wantUpdateWeightsErr)
 			}
@@ -453,7 +524,8 @@ func TestUpdateWeights(t *testing.T) {
 
 		chooserFn func(choices ...weightedRand.Choice) (*weightedRand.Chooser, error)
 
-		wantErr error
+		wantInitErr error
+		wantErr     error
 	}{
 		{
 			name: "ok",
@@ -493,7 +565,8 @@ func TestUpdateWeights(t *testing.T) {
 				return nil, mockError
 			},
 
-			wantErr: mockError,
+			wantInitErr: mockError,
+			wantErr:     mockError,
 		},
 	}
 
@@ -506,9 +579,17 @@ func TestUpdateWeights(t *testing.T) {
 				newChooserFn = weightedRand.NewChooser
 			}()
 
-			optimizationTable := NewTranslationTable(11)
+			optimizationTable, err := NewTranslationTable(11)
+			if !errors.Is(err, tt.wantInitErr) {
+				t.Fatalf("got %v, want %v", err, tt.wantInitErr)
+				return
+			}
 
-			err := optimizationTable.UpdateWeights(tt.aminoAcids)
+			if tt.wantInitErr != nil {
+				return
+			}
+
+			err = optimizationTable.UpdateWeights(tt.aminoAcids)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got %v, want %v", err, tt.wantErr)
 			}

--- a/synthesis/codon/example_test.go
+++ b/synthesis/codon/example_test.go
@@ -11,7 +11,13 @@ import (
 func ExampleTranslationTable_Translate() {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 	gfpDnaSequence := "ATGGCTAGCAAAGGAGAAGAACTTTTCACTGGAGTTGTCCCAATTCTTGTTGAATTAGATGGTGATGTTAATGGGCACAAATTTTCTGTCAGTGGAGAGGGTGAAGGTGATGCTACATACGGAAAGCTTACCCTTAAATTTATTTGCACTACTGGAAAACTACCTGTTCCATGGCCAACACTTGTCACTACTTTCTCTTATGGTGTTCAATGCTTTTCCCGTTATCCGGATCATATGAAACGGCATGACTTTTTCAAGAGTGCCATGCCCGAAGGTTATGTACAGGAACGCACTATATCTTTCAAAGATGACGGGAACTACAAGACGCGTGCTGAAGTCAAGTTTGAAGGTGATACCCTTGTTAATCGTATCGAGTTAAAAGGTATTGATTTTAAAGAAGATGGAAACATTCTCGGACACAAACTCGAGTACAACTATAACTCACACAATGTATACATCACGGCAGACAAACAAAAGAATGGAATCAAAGCTAACTTCAAAATTCGCCACAACATTGAAGATGGATCCGTTCAACTAGCAGACCATTATCAACAAAATACTCCAATTGGCGATGGCCCTGTCCTTTTACCAGACAACCATTACCTGTCGACACAATCTGCCCTTTCGAAAGATCCCAACGAAAAGCGTGACCACATGGTCCTTCTTGAGTTTGTAACTGCTGCTGGGATTACACATGGCATGGATGAGCTCTACAAATAA"
-	testTranslation, _ := codon.NewTranslationTable(11).Translate(gfpDnaSequence) // need to specify which codons map to which amino acids per NCBI table
+	table, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
+	testTranslation, _ := table.Translate(gfpDnaSequence) // need to specify which codons map to which amino acids per NCBI table
 
 	fmt.Println(gfpTranslation == testTranslation)
 	// output: true
@@ -19,14 +25,19 @@ func ExampleTranslationTable_Translate() {
 
 func ExampleTranslationTable_UpdateWeights() {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
-	sequenceWithCustomWeights := "ATGGCAAGTAAGGGAGAAGAGCTTTTTACCGGCGTAGTACCAATTCTGGTAGAACTGGATGGTGATGTAAACGGTCACAAATTTAGTGTAAGCGGAGAAGGTGAGGGTGATGCTACCTATGGCAAACTGACCCTAAAGTTTATATGCACGACTGGAAAACTTCCGGTACCGTGGCCAACGTTAGTTACAACGTTTTCTTATGGAGTACAGTGCTTCAGCCGCTACCCAGATCATATGAAACGCCATGATTTCTTTAAGAGCGCCATGCCAGAGGGTTATGTTCAGGAGCGCACGATCTCGTTTAAGGATGATGGTAACTATAAGACTCGTGCTGAGGTGAAGTTCGAAGGCGATACCCTTGTAAATCGTATTGAATTGAAGGGTATAGACTTCAAGGAGGATGGAAATATTCTTGGACATAAGCTGGAATACAATTACAATTCACATAACGTTTATATAACTGCCGACAAGCAAAAAAACGGGATAAAAGCTAATTTTAAAATACGCCACAACATAGAGGACGGGTCGGTGCAACTAGCCGATCATTATCAACAAAACACACCAATCGGCGACGGACCAGTTCTGTTGCCCGATAATCATTACTTATCAACCCAAAGTGCCTTAAGTAAGGATCCGAACGAAAAGCGCGATCATATGGTACTTCTTGAGTTTGTTACCGCTGCAGGCATAACGCATGGCATGGACGAGCTATACAAATAA"
 
-	table := codon.NewTranslationTable(11)
+	sequenceWithCustomWeights := "ATGGCGAGCAAGGGCGAAGAGCTTTTTACTGGAGTGGTACCCATCCTTGTGGAGCTGGATGGGGATGTTAATGGGCACAAGTTTTCTGTGTCCGGTGAGGGGGAGGGTGACGCGACCTATGGCAAACTAACGTTGAAGTTTATCTGCACCACCGGCAAGCTCCCTGTCCCTTGGCCGACGCTGGTAACCACTTTTTCATACGGAGTGCAATGCTTTTCACGATACCCAGACCACATGAAACGGCACGACTTCTTCAAGAGCGCGATGCCAGAAGGTTATGTGCAAGAGCGTACGATCTCATTCAAGGACGACGGGAATTATAAGACAAGAGCAGAGGTGAAATTTGAGGGGGACACGTTAGTAAATCGGATTGAATTAAAGGGAATCGACTTTAAGGAGGATGGGAACATACTTGGTCACAAACTGGAATATAATTACAATTCACACAATGTTTACATCACTGCCGACAAGCAAAAAAATGGGATTAAAGCAAATTTCAAAATTCGGCATAATATTGAGGATGGTAGTGTCCAGCTCGCGGATCACTATCAGCAAAACACACCTATCGGAGACGGACCCGTTTTACTACCGGATAATCATTACTTAAGCACCCAATCAGCGTTATCCAAAGATCCGAACGAAAAACGTGACCACATGGTTCTCTTGGAGTTCGTCACCGCAGCTGGAATAACTCATGGAATGGACGAACTATACAAATAA"
+
+	table, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
 
 	// this example is using custom weights for different codons for Arginine. Use this if you would rather use your own
 	// codon weights, they can also be computed for you with `UpdateWeightsWithSequence`.
 
-	err := table.UpdateWeights([]codon.AminoAcid{
+	err = table.UpdateWeights([]codon.AminoAcid{
 		{
 			Letter: "R",
 			Codons: []codon.Codon{
@@ -57,7 +68,11 @@ func ExampleTranslationTable_UpdateWeights() {
 		fmt.Println("Could not update weights in example")
 	}
 
-	optimizedSequence, _ := table.Optimize(gfpTranslation, 1)
+	optimizedSequence, err := table.Optimize(gfpTranslation, 1)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
 
 	fmt.Println(optimizedSequence == sequenceWithCustomWeights)
 	// output: true
@@ -67,7 +82,12 @@ func ExampleTranslationTable_Optimize() {
 	gfpTranslation := "MASKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKRHDFFKSAMPEGYVQERTISFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYITADKQKNGIKANFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK*"
 
 	sequence, _ := genbank.Read("../../data/puc19.gbk")
-	codonTable := codon.NewTranslationTable(11)
+	codonTable, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
 	_ = codonTable.UpdateWeightsWithSequence(sequence)
 
 	// Here, we double check if the number of genes is equal to the number of stop codons
@@ -122,14 +142,24 @@ func ExampleCompromiseCodonTable() {
 	sequence, _ := genbank.Read("../../data/puc19.gbk")
 
 	// weight our codon optimization table using the regions we collected from the genbank file above
-	optimizationTable := codon.NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		panic(fmt.Errorf("got unexpected error in an example: %w", err))
 	}
 
 	sequence2, _ := genbank.Read("../../data/phix174.gb")
-	optimizationTable2 := codon.NewTranslationTable(11)
+	optimizationTable2, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
 	err = optimizationTable2.UpdateWeightsWithSequence(sequence2)
 	if err != nil {
 		panic(fmt.Errorf("got unexpected error in an example: %w", err))
@@ -143,21 +173,31 @@ func ExampleCompromiseCodonTable() {
 			}
 		}
 	}
-	//output: 2727
+	//output: 3863
 }
 
 func ExampleAddCodonTable() {
 	sequence, _ := genbank.Read("../../data/puc19.gbk")
 
 	// weight our codon optimization table using the regions we collected from the genbank file above
-	optimizationTable := codon.NewTranslationTable(11)
-	err := optimizationTable.UpdateWeightsWithSequence(sequence)
+	optimizationTable, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
+	err = optimizationTable.UpdateWeightsWithSequence(sequence)
 	if err != nil {
 		panic(fmt.Errorf("got unexpected error in an example: %w", err))
 	}
 
 	sequence2, _ := genbank.Read("../../data/phix174.gb")
-	optimizationTable2 := codon.NewTranslationTable(11)
+	optimizationTable2, err := codon.NewTranslationTable(11)
+	if err != nil {
+		fmt.Printf("error running example: %s\n", err)
+		return
+	}
+
 	err = optimizationTable2.UpdateWeightsWithSequence(sequence2)
 	if err != nil {
 		panic(fmt.Errorf("got unexpected error in an example: %w", err))
@@ -175,5 +215,5 @@ func ExampleAddCodonTable() {
 			}
 		}
 	}
-	//output: 90
+	//output: 51
 }


### PR DESCRIPTION
## Changes in this PR

The hardcoded codon table objects are no longer generated at buildtime (which makes them global variables prone to being changed by an unexpected process) but initialised as part of their constructor; `NewTranslationTable`. This ensures that the package examples and tests run in proper isolation (and that no consumer gets surprised when they modify a table's weights and find that they've also updated a separate, unrelated table).

This PR also makes the codonTable.Copy() function [less naive](https://stackoverflow.com/questions/56355212/deep-copying-data-structures-in-golang), which was [originally created](https://github.com/bebop/poly/pull/350#discussion_r1333319177) to avoid this "global variable" problem but was too naive. Ideally we would not need to make deep copies; but it is used in `CompromiseCodonTable` and `AddCodonTable`

### Why are you making these changes?

Some examples in the codon package gave different results depending if they were run on their own or if they were run as part of the whole test suite, specifically `ExampleTranslationTable_UpdateWeights`

// go test -run=ExampleTranslationTable_UpdateWeights ./synthesis/codon -count=1
```
--- FAIL: ExampleTranslationTable_UpdateWeights (0.00s)
got:
false
want:
true
```
// go test ./... -count=1
```
?       github.com/bebop/poly   [no test files]
ok      github.com/bebop/poly/align     0.149s
ok      github.com/bebop/poly/align/matrix      0.308s
ok      github.com/bebop/poly/alphabet  0.202s
ok      github.com/bebop/poly/checks    0.521s
ok      github.com/bebop/poly/clone     0.415s
ok      github.com/bebop/poly/fold      0.831s
ok      github.com/bebop/poly/io        0.735s [no tests to run]
ok      github.com/bebop/poly/io/fasta  0.939s
ok      github.com/bebop/poly/io/fastq  0.945s
ok      github.com/bebop/poly/io/genbank        0.984s
ok      github.com/bebop/poly/io/gff    0.993s
ok      github.com/bebop/poly/io/pileup 1.047s
?       github.com/bebop/poly/synthesis [no test files]
ok      github.com/bebop/poly/io/polyjson       1.001s
ok      github.com/bebop/poly/io/rebase 1.013s
ok      github.com/bebop/poly/io/slow5  1.070s
ok      github.com/bebop/poly/io/uniprot        0.926s
ok      github.com/bebop/poly/mash      0.950s
ok      github.com/bebop/poly/primers   0.958s
ok      github.com/bebop/poly/primers/pcr       1.010s
ok      github.com/bebop/poly/random    1.036s
ok      github.com/bebop/poly/seqhash   1.082s
ok      github.com/bebop/poly/synthesis/codon   0.937s
ok      github.com/bebop/poly/synthesis/fix     1.133s
ok      github.com/bebop/poly/synthesis/fragment        0.953s
ok      github.com/bebop/poly/transform 0.980s
ok      github.com/bebop/poly/transform/variants        0.942s
ok      github.com/bebop/poly/tutorials 0.967s
```

This was due to the fact that the generated codon tables were global variables, so the tests which ran before `ExampleTranslationTable_UpdateWeights` modified the (pseudorandom) sequence we got out when running `table.Optimize`. If you ran the test by itself it behaved as if you were running it in isolation (which was presumably intended) The expected output was therefore incorrect.

The change makes it so the tables are no longer global variables, so `ExampleTranslationTable_UpdateWeights` now gives the same output if it runs as part of the whole test suit or on its own

### Are any changes breaking? (IMPORTANT)

No

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [x] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [x] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [x] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
