### PR TITLE
added some more test coverage to fold subpackage.

### DIFF
--- a/fold/fold_test.go
+++ b/fold/fold_test.go
@@ -1,6 +1,7 @@
 package fold
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -200,4 +201,14 @@ func TestFold(t *testing.T) {
 		require.NoError(t, err)
 		assert.InDelta(t, struc.energy, -4.2, 0.2)
 	})
+}
+func TestZuker_ErrorCreatingFoldingContext(t *testing.T) {
+	seq := "ATGGATTTAGATAGATADFQ#(RSDOFIA)"
+	temp := 4000.0
+
+	expectedErr := fmt.Errorf("error creating folding context: the sequence ATGGATTTAGATAGATADFQ#(RSDOFIA) is not RNA or DNA")
+
+	_, err := Zuker(seq, temp)
+	require.Error(t, err)
+	assert.Equal(t, expectedErr.Error(), err.Error())
 }

--- a/fold/seqfold_test.go
+++ b/fold/seqfold_test.go
@@ -1,0 +1,43 @@
+package fold
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestResult_MinimumFreeEnergy_LengthZero(t *testing.T) {
+	result := Result{} // Create a Result instance with empty structs
+
+	expectedEnergy := math.Inf(1)
+	actualEnergy := result.MinimumFreeEnergy()
+
+	if actualEnergy != expectedEnergy {
+		t.Errorf("expected energy to be %f, but got %f", expectedEnergy, actualEnergy)
+	}
+}
+
+func TestResult_DotBracket_LengthZero(t *testing.T) {
+	result := Result{} // Create a Result instance with empty structs
+
+	expectedDotBracket := ""
+	actualDotBracket := result.DotBracket()
+
+	if actualDotBracket != expectedDotBracket {
+		t.Errorf("expected dot bracket to be %s, but got %s", expectedDotBracket, actualDotBracket)
+	}
+}
+
+func TestNewFoldingContext_InvalidSequence(t *testing.T) {
+	seq := "XYZ"
+	temp := 37.0
+
+	_, err := newFoldingContext(seq, temp)
+	if err == nil {
+		t.Errorf("expected error, but got nil")
+	}
+	expectedError := fmt.Errorf("the sequence %s is not RNA or DNA", seq)
+	if err.Error() != expectedError.Error() {
+		t.Errorf("expected error message to be %q, but got %q", expectedError.Error(), err.Error())
+	}
+}


### PR DESCRIPTION
## Changes in this PR
added some more test coverage to fold subpackage.
<!--
*Clearly and concisely summarize the changes you are making. Bullet points are completely okay. Please be specific, saying "improves X" is not enough!*
-->

### Why are you making these changes?
To increase code coverage of fold package.
<!--
*Explain why these changes are necessary. Link to GitHub issues here with the format `fixes: #XXX` to indicate this PR resolves the issue.*
-->

### Are any changes breaking? (IMPORTANT)
No
<!--
*Will merging this PR change `poly`'s API in a non-backwards-compatible manner?*

*Examples of breaking changes:*
* *Removing a method from a struct.*
* *Deleting/moving a package.*
* *Adding a method to an interface (client may have made their own     implementation of this interface, and adding a method to the     interface could cause client's implementation to no longer satisfy     the interface).*

*Examples of non-breaking changes:*
* *Adding a method to a struct.*
* *Adding a function.*
* *Fixing a bug in a function/method.*
* *Creating a new package.*
-->

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [ ] New packages/exported functions have docstrings.
* [ ] New/changed functionality is thoroughly tested.
* [ ] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [ ] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [ ] All code is properly formatted and linted.
* [ ] The PR template is filled out.
