### PR TITLE
updated devcontainer image.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,15 +2,8 @@
 {
 	"name": "poly-devcontainer",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1.23-bookworm",
 
-	"features": {
-		"ghcr.io/devcontainers/features/go:1": {
-			"version": "latest",
-			"golangciLintVersion": "latest"
-		},
-	},
-	
 	"extensions": ["golang.go"],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
## Changes in this PR

Updating the devcontainer to use go 1.23 and debian 12 `bookworm`.


### Why are you making these changes?

Originally wanted to use a smaller dev container for faster builds but the official Go devcontainer images don't support alpine?

### Are any changes breaking? (IMPORTANT)

No. It builds and all tests pass within the build.

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [X] New/changed functionality is thoroughly tested.
* [X] All code is properly formatted and linted.
* [X] The PR template is filled out.
